### PR TITLE
Dependency versions updated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   ],
   "require": {
     "php": ">=7.2",
-    "guzzlehttp/guzzle": "^6.3",
+    "guzzlehttp/guzzle": "^7.0",
     "ramsey/uuid": "^4",
     "symfony/property-access": "^5",
     "symfony/serializer": "^5",
@@ -41,6 +41,6 @@
     "test": "codecept run"
   },
   "require-dev": {
-    "codeception/codeception": "^2.5"
+    "codeception/codeception": "^4.0"
   }
 }


### PR DESCRIPTION
Guzzle client dependency upgraded to ^7.0 to support newer projects relying on this version in other packages.
Dependent Codeception package version also upgraded.